### PR TITLE
Added .editorconfig file to enforce spaces in the solution

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+; Top-most http://editorconfig.org/ file
+root = true
+
+; 4-space indentation
+[*.cs]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
See [the Microsoft post](https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options) and [the official website](https://editorconfig.org) for more information.
This *should* ensure that spaces are used regardless of IDE settings.