### PR TITLE
MemeCommand comparison fix

### DIFF
--- a/SteakBot.Core/Objects/MemeCommand.cs
+++ b/SteakBot.Core/Objects/MemeCommand.cs
@@ -68,12 +68,12 @@ namespace SteakBot.Core.Objects
 
         public static bool operator ==(MemeCommand lhs, MemeCommand rhs)
         {
-            return lhs.Equals(rhs);
+            return (ReferenceEquals(lhs, null) && ReferenceEquals(rhs, null)) || lhs.Equals(rhs);
         }
 
         public static bool operator !=(MemeCommand lhs, MemeCommand rhs)
         {
-            return !lhs.Equals(rhs);
+            return (ReferenceEquals(lhs, null) && !ReferenceEquals(rhs, null)) || !lhs.Equals(rhs);
         }
 
         #endregion


### PR DESCRIPTION
Fixed MemeCommand comparison against null values.

(cherry picked from commit 6feedcfd7f0c27fcd57d00b37dde7688eccfea65)