### PR TITLE
Fixed bug with delete command character

### DIFF
--- a/SteakBot.Core/EventHandlers/CustomMessageHandlers/CommandMessageHandlers/BaseCommandMessageHandler.cs
+++ b/SteakBot.Core/EventHandlers/CustomMessageHandlers/CommandMessageHandlers/BaseCommandMessageHandler.cs
@@ -8,16 +8,13 @@ namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.CommandMessageHandle
 {
     internal abstract class BaseCommandMessageHandler : ICustomMessageHandler
     {
-        protected const string CommandChar = "]";
-        protected const string DeleteMessageChar = "[";
-
         protected IEnumerable<string> CommandNames;
 
         public bool CanHandle(SocketUserMessage message)
         {
             var messageString = message.Content;
-            var commandText = messageString.Replace(CommandChar, "").Replace(DeleteMessageChar, "").Split(' ', '\n')[0];
-            return messageString.StartsWith(CommandChar) && CommandNames.Any(x => x == commandText);
+            var commandText = messageString.Replace(GlobalConstants.CommandChar, "").Split(' ', '\n')[0];
+            return messageString.StartsWith(GlobalConstants.CommandChar) && CommandNames.Any(x => x == commandText);
         }
 
         public void Invoke(SocketUserMessage message)

--- a/SteakBot.Core/EventHandlers/CustomMessageHandlers/CommandMessageHandlers/CustomCommandMessageHandler.cs
+++ b/SteakBot.Core/EventHandlers/CustomMessageHandlers/CommandMessageHandlers/CustomCommandMessageHandler.cs
@@ -20,8 +20,21 @@ namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.CommandMessageHandle
         protected override bool InvokeInner(SocketUserMessage message)
         {
             var channel = message.Channel;
-            var commandText = message.Content.Replace(CommandChar, "").Replace(DeleteMessageChar, "");
-            var command = _memeService.MemeCommands.Single(x => x.Name == commandText);
+            var messageText = message.Content;
+
+            var startIndex = 0;
+            var endIndex = messageText.Length;
+            if (messageText.StartsWith(GlobalConstants.CommandChar))
+            {
+                startIndex++;
+            }
+            if (messageText.EndsWith(GlobalConstants.DeleteMessageChar))
+            {
+                endIndex--;
+            }
+            var commandName = messageText.Substring(startIndex, endIndex);
+
+            var command = _memeService.MemeCommands.Single(x => x.Name == commandName);
             switch (command.ResultType)
             {
                 case MemeResultType.Text:

--- a/SteakBot.Core/EventHandlers/CustomMessageHandlers/CommandMessageHandlers/CustomCommandMessageHandler.cs
+++ b/SteakBot.Core/EventHandlers/CustomMessageHandlers/CommandMessageHandlers/CustomCommandMessageHandler.cs
@@ -23,16 +23,12 @@ namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.CommandMessageHandle
             var messageText = message.Content;
 
             var startIndex = 0;
-            var endIndex = messageText.Length;
             if (messageText.StartsWith(GlobalConstants.CommandChar))
             {
                 startIndex++;
             }
-            if (messageText.EndsWith(GlobalConstants.DeleteMessageChar))
-            {
-                endIndex--;
-            }
-            var commandName = messageText.Substring(startIndex, endIndex);
+
+            var commandName = messageText.Substring(startIndex);
 
             var command = _memeService.MemeCommands.Single(x => x.Name == commandName);
             switch (command.ResultType)

--- a/SteakBot.Core/EventHandlers/CustomMessageHandlers/CommandMessageHandlers/StandardCommandMessageHandler.cs
+++ b/SteakBot.Core/EventHandlers/CustomMessageHandlers/CommandMessageHandlers/StandardCommandMessageHandler.cs
@@ -18,7 +18,7 @@ namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.CommandMessageHandle
             _client = client;
             _commands = commands;
             _serviceProvider = serviceProvider;
-            _commandChar = CommandChar[0];
+            _commandChar = GlobalConstants.CommandChar[0];
             CommandNames = _commands.Commands.Select(x => x.Name);
         }
 
@@ -28,6 +28,7 @@ namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.CommandMessageHandle
             message.HasCharPrefix(_commandChar, ref argumentPosition);
 
             var context = new SocketCommandContext(_client, message);
+
             var result = _commands.ExecuteAsync(context, argumentPosition, _serviceProvider).Result;
             if (!result.IsSuccess)
             {
@@ -39,7 +40,7 @@ namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.CommandMessageHandle
 
         protected override bool ShouldDeleteMessage(SocketUserMessage message)
         {
-            return message.Content.EndsWith(DeleteMessageChar);
+            return message.Content.EndsWith(GlobalConstants.DeleteMessageChar);
         }
     }
 }

--- a/SteakBot.Core/GlobalConstants.cs
+++ b/SteakBot.Core/GlobalConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace SteakBot.Core
+{
+    public class GlobalConstants
+    {
+        public const string CommandChar = "]";
+        public const string DeleteMessageChar = "[";
+    }
+}

--- a/SteakBot.Core/Modules/ChatModule.cs
+++ b/SteakBot.Core/Modules/ChatModule.cs
@@ -9,7 +9,7 @@ namespace SteakBot.Core.Modules
         [Summary("Bot says \"Hi\"")]
         public async Task Hi()
         {
-            await ReplyAsync($"Hi, {Context.User.Mention} !");
+            await ReplyAsync($"Hi, {Context.User.Mention}!");
         }
 
         [Command("say")]
@@ -21,6 +21,7 @@ namespace SteakBot.Core.Modules
             {
                 message = message.Substring(0, message.Length - 1);
             }
+
             await ReplyAsync(message);
         }
     }

--- a/SteakBot.Core/Modules/ChatModule.cs
+++ b/SteakBot.Core/Modules/ChatModule.cs
@@ -17,6 +17,10 @@ namespace SteakBot.Core.Modules
         [Remarks("Usage: `say <something>`")]
         public async Task Say([Remainder]string message)
         {
+            if (message.EndsWith(GlobalConstants.DeleteMessageChar))
+            {
+                message = message.Substring(0, message.Length - 1);
+            }
             await ReplyAsync(message);
         }
     }

--- a/SteakBot.Core/Modules/HelpModule.cs
+++ b/SteakBot.Core/Modules/HelpModule.cs
@@ -37,12 +37,13 @@ namespace SteakBot.Core.Modules
         [Remarks("Usage: `list <filter(text)>`")]
         public async Task List(string filter)
         {
+            var filterToLower = filter.ToLower();
             var memeCommands = _memeService.MemeCommands;
             if (!string.IsNullOrWhiteSpace(filter))
             {
                 memeCommands = memeCommands
-                    .Where(x => x.Name.Contains(filter) ||
-                                x.Description.Contains(filter))
+                    .Where(x => x.Name.ToLower().Contains(filterToLower) ||
+                                x.Description.ToLower().Contains(filterToLower))
                     .ToList();
             }
 
@@ -61,13 +62,15 @@ namespace SteakBot.Core.Modules
         [Remarks("Usage: `help <filter(text)>`")]
         public async Task Help(string filter)
         {
+            var filterToLower = filter.ToLower();
+
             var commands = _commandService.Commands;
             if (!string.IsNullOrWhiteSpace(filter))
             {
                 commands = commands
-                    .Where(x => x.Name.Contains(filter) ||
-                                (x.Remarks != null && x.Remarks.Contains(filter)) ||
-                                (x.Summary != null && x.Summary.Contains(filter)));
+                    .Where(x => x.Name.ToLower().Contains(filterToLower) ||
+                                (x.Remarks != null && x.Remarks.ToLower().Contains(filterToLower)) ||
+                                (x.Summary != null && x.Summary.ToLower().Contains(filterToLower)));
             }
 
             await ReplyHelpMessage(commands.ToArray());

--- a/SteakBot.Core/Services/QuotingService.cs
+++ b/SteakBot.Core/Services/QuotingService.cs
@@ -120,9 +120,9 @@ namespace SteakBot.Core.Services
             var embed = new EmbedBuilder
             {
                 Color = Color.Blue,
-                Author = BuildAuthorEmbed(quoteMetadata.Author, quoteMetadata.AuthorName),
+                Author = BuildAuthorEmbed(quoteMetadata?.Author, quoteMetadata?.AuthorName),
                 Description = string.Join("\n", lines),
-                Footer = BuildFooterEmbed(referredChannel, quoteMetadata.Timestamp)
+                Footer = BuildFooterEmbed(referredChannel, quoteMetadata?.Timestamp)
             };
 
             return embed.Build();


### PR DESCRIPTION
To the point:
Fixed a bug where delete command character was not being removed on executing a `say` command.
Added `GlobalConstants` file.
Removed delete char handling of the command since we auto delete it if it's a custom command and basic commands (e.g. `]hi[`) cannot be invoked currently.

Miscellaneous:
Removed an extra space in `hi` command reponse.
Made help and list command filters case insensitive.