### PR TITLE
Added issue number parsing and GitHub integration

### DIFF
--- a/SteakBot.Core/DependencyInjection/ServiceProviderExtensions.cs
+++ b/SteakBot.Core/DependencyInjection/ServiceProviderExtensions.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using Discord.Commands;
+﻿using Discord.Commands;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
 using SteakBot.Core.EventHandlers;
 using SteakBot.Core.EventHandlers.Abstraction;
 using SteakBot.Core.EventHandlers.CustomMessageHandlers;
 using SteakBot.Core.EventHandlers.CustomMessageHandlers.CommandMessageHandlers;
+using SteakBot.Core.EventHandlers.CustomMessageHandlers.NumberParsingMessageHandlers.GitHubIssueNumberMessageHandlers;
 using SteakBot.Core.Modules;
 using SteakBot.Core.Services;
 using SteakBot.Core.TypeReaders;
@@ -56,6 +56,12 @@ namespace SteakBot.Core.DependencyInjection
             return serviceCollection
                 .AddSingleton<ICustomMessageHandler, CustomCommandMessageHandler>()
                 .AddSingleton<ICustomMessageHandler, StandardCommandMessageHandler>();
+        }
+
+        public static IServiceCollection AddGitHubIntegrationServices(this IServiceCollection serviceCollection)
+        {
+            return serviceCollection
+                .AddSingleton<ICustomMessageHandler, SteakBotGitHubNumberParsingMessageHandler>();
         }
     }
 }

--- a/SteakBot.Core/DependencyInjection/ServiceProviderExtensions.cs
+++ b/SteakBot.Core/DependencyInjection/ServiceProviderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Discord.Commands;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
+using Octokit;
 using SteakBot.Core.EventHandlers;
 using SteakBot.Core.EventHandlers.Abstraction;
 using SteakBot.Core.EventHandlers.CustomMessageHandlers;
@@ -61,6 +62,7 @@ namespace SteakBot.Core.DependencyInjection
         public static IServiceCollection AddGitHubIntegrationServices(this IServiceCollection serviceCollection)
         {
             return serviceCollection
+                .AddSingleton<IGitHubClient>(provider => new GitHubClient(new ProductHeaderValue("SteakBot")))
                 .AddSingleton<ICustomMessageHandler, SteakBotGitHubNumberParsingMessageHandler>();
         }
     }

--- a/SteakBot.Core/DependencyInjection/ServiceProviderExtensions.cs
+++ b/SteakBot.Core/DependencyInjection/ServiceProviderExtensions.cs
@@ -63,7 +63,8 @@ namespace SteakBot.Core.DependencyInjection
         {
             return serviceCollection
                 .AddSingleton<IGitHubClient>(provider => new GitHubClient(new ProductHeaderValue("SteakBot")))
-                .AddSingleton<ICustomMessageHandler, SteakBotGitHubNumberParsingMessageHandler>();
+                .AddSingleton<ICustomMessageHandler, SteakBotGitHubNumberParsingMessageHandler>()
+                .AddSingleton<ICustomMessageHandler, OpenRaGitHubIssueNumberMessageHandler>();
         }
     }
 }

--- a/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/BaseNumberParsingMessageHandler.cs
+++ b/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/BaseNumberParsingMessageHandler.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Discord.WebSocket;
+
+namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.NumberParsingMessageHandlers
+{
+    internal abstract class BaseNumberParsingMessageHandler : ICustomMessageHandler
+    {
+        protected abstract Dictionary<string, int> MinimumHandledNumberPerKeyword { get; }
+
+        protected virtual string[] RegexMatchPatternKeywords => MinimumHandledNumberPerKeyword.Keys.ToArray();
+
+        protected virtual string RegexMatchPattern { get; } = "(^|[^a-zA-Z0-9])({keyword}#[0-9]+)";
+
+        protected virtual bool RegexMatchCase { get; } = false;
+
+        private readonly RegexOptions _regexOptions;
+        private readonly string[] _regexMatchPatterns;
+
+        internal BaseNumberParsingMessageHandler()
+        {
+            _regexOptions = RegexMatchCase ? RegexOptions.Compiled : RegexOptions.Compiled | RegexOptions.IgnoreCase;
+            _regexMatchPatterns = RegexMatchPatternKeywords.Select(x => RegexMatchPattern.Replace("{keyword}", x)).ToArray();
+        }
+
+        public bool CanHandle(SocketUserMessage message)
+        {
+            // This can be simplified when the codebase is migrated to C# 8 / .NET Standard 2.1
+            var matchCollectionForPattern = _regexMatchPatterns.Select(regexMatchPattern => Regex.Matches(message.Content, regexMatchPattern, _regexOptions));
+            foreach (var matchCollection in matchCollectionForPattern)
+            {
+                foreach (Match match in matchCollection)
+                {
+                    var split = match.Groups[match.Groups.Count - 1].Value.Split('#');
+                    var keyword = split[0];
+                    if (int.TryParse(split[1], out var number) && MinimumHandledNumberPerKeyword[keyword] <= number)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public abstract void Invoke(SocketUserMessage message);
+
+        protected IEnumerable<int> GetMatchedNumbers(string message)
+        {
+            // This can be simplified when the codebase is migrated to C# 8 / .NET Standard 2.1
+            var matchCollectionForPattern = _regexMatchPatterns.Select(regexMatchPattern => Regex.Matches(message, regexMatchPattern, _regexOptions));
+            foreach (var matchCollection in matchCollectionForPattern)
+            {
+                foreach (Match match in matchCollection)
+                {
+                    yield return int.Parse(match.Groups[match.Groups.Count - 1].Value.Split('#')[1]);
+                }
+            }
+        }
+    }
+}

--- a/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/GitHubIssueNumberMessageHandlers/BaseGitHubIssueNumberMessageHandler.cs
+++ b/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/GitHubIssueNumberMessageHandlers/BaseGitHubIssueNumberMessageHandler.cs
@@ -15,6 +15,8 @@ namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.NumberParsingMessage
 
         private static readonly string IssueIconBaseUrl = ConfigurationManager.AppSettings["GitHubIconsBaseUrl"];
 
+        private static readonly bool ShouldShowRepositoryIcon = bool.Parse(ConfigurationManager.AppSettings["ShowRepositoryIcon"]);
+
         private readonly IGitHubClient _gitHubClient;
         private readonly Dictionary<string, Color> _colorPerStatus = new Dictionary<string, Color>
         {
@@ -89,7 +91,7 @@ namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.NumberParsingMessage
                     Footer = new EmbedFooterBuilder
                     {
                         Text = $"Created at {issue.CreatedAt.ToString("s").Replace('T', ' ') + " UTC"}",
-                        IconUrl = ownerUser.AvatarUrl
+                        IconUrl = ShouldShowRepositoryIcon ? ownerUser.AvatarUrl : null
                     },
                     Timestamp = issue.UpdatedAt,
                     Color = _colorPerStatus[status.StringValue]

--- a/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/GitHubIssueNumberMessageHandlers/BaseGitHubIssueNumberMessageHandler.cs
+++ b/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/GitHubIssueNumberMessageHandlers/BaseGitHubIssueNumberMessageHandler.cs
@@ -1,0 +1,102 @@
+﻿using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using Discord;
+using Discord.WebSocket;
+using Octokit;
+
+namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.NumberParsingMessageHandlers.GitHubIssueNumberMessageHandlers
+{
+    internal abstract class BaseGitHubIssueNumberMessageHandler : BaseNumberParsingMessageHandler
+    {
+        protected abstract string RepositoryOwner { get; }
+
+        protected abstract string RepositoryName { get; }
+
+        private static readonly string IssueIconBaseUrl = ConfigurationManager.AppSettings["GitHubIconsBaseUrl"];
+
+        private readonly Dictionary<string, Color> _colorPerStatus = new Dictionary<string, Color>
+        {
+            { "open", Color.Green },
+            { "closed", Color.Red },
+            { "merged", Color.Purple }
+        };
+
+        public override void Invoke(SocketUserMessage message)
+        {
+            var client = new GitHubClient(new ProductHeaderValue("SteakBot"));
+            var ownerUser = client.User.Get(RepositoryOwner).Result;
+            foreach (var number in GetMatchedNumbers(message.Content))
+            {
+                var issue = client.Issue.Get(RepositoryOwner, RepositoryName, number).Result;
+                var isIssue = issue.PullRequest == null;
+                var type = isIssue ? "Issue" : "Pull request";
+                var labels = string.Join(", ", issue.Labels?.Select(x => x.Name) ?? Enumerable.Empty<string>());
+                var embedFields = new List<EmbedFieldBuilder>();
+                if (!string.IsNullOrEmpty(labels))
+                {
+                    embedFields.Add(new EmbedFieldBuilder
+                    {
+                        Name = "Labels:",
+                        Value = labels,
+                        IsInline = true
+                    });
+                }
+
+                var status = issue.State;
+
+                if (!isIssue && status == "Closed")
+                {
+                    var pullRequest = client.PullRequest.Get(RepositoryOwner, RepositoryName, number).Result;
+
+                    embedFields.Add(new EmbedFieldBuilder
+                    {
+                        Name = "Status:",
+                        Value = pullRequest.MergeableState,
+                        IsInline = true
+                    });
+
+                    status = pullRequest.Merged ? "merged" : issue.State;
+                    if (pullRequest.Merged)
+                    {
+                        embedFields.Add(new EmbedFieldBuilder
+                        {
+                            Name = "Merged by:",
+                            Value = pullRequest.MergedBy?.Login,
+                            IsInline = true
+                        });
+                    }
+                }
+
+                var embed = new EmbedBuilder
+                {
+                    Title = issue.Title,
+                    ThumbnailUrl = issue.User?.AvatarUrl,
+                    Url = issue.HtmlUrl,
+                    Description = issue.Body.Length > 250 ? issue.Body.Substring(0, 250) + "..." : issue.Body,
+                    Author = new EmbedAuthorBuilder
+                    {
+                        Name = $"{type} #{number} by {issue.User?.Login}  ({status})",
+                        IconUrl = GetIssueIconUrl(isIssue, status.StringValue),
+                        Url = issue.HtmlUrl
+                    },
+                    Fields = embedFields,
+                    Footer = new EmbedFooterBuilder
+                    {
+                        Text = $"Created at {issue.CreatedAt.ToString("s").Replace('T', ' ') + " UTC"}",
+                        IconUrl = ownerUser.AvatarUrl
+                    },
+                    Timestamp = issue.UpdatedAt,
+                    Color = _colorPerStatus[status.StringValue]
+                };
+
+                message.Channel.SendMessageAsync("", embed: embed.Build());
+            }
+        }
+
+        private static string GetIssueIconUrl(bool isIssue, string status)
+        {
+            return $"{IssueIconBaseUrl}/github-{(isIssue ? "issue" : "pr")}-{status}.png";
+        }
+    }
+}

--- a/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/GitHubIssueNumberMessageHandlers/OpenRaGitHubIssueNumberMessageHandler.cs
+++ b/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/GitHubIssueNumberMessageHandlers/OpenRaGitHubIssueNumberMessageHandler.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Octokit;
+
+namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.NumberParsingMessageHandlers.GitHubIssueNumberMessageHandlers
+{
+    internal class OpenRaGitHubIssueNumberMessageHandler : BaseGitHubIssueNumberMessageHandler
+    {
+        protected override string RepositoryOwner { get; } = "OpenRA";
+
+        protected override string RepositoryName { get; } = "OpenRA";
+
+        protected override Dictionary<string, int> MinimumHandledNumberPerKeyword { get; } = new Dictionary<string, int>
+        {
+            { string.Empty, 2000 },
+            { "ora", 0 }
+        };
+
+        public OpenRaGitHubIssueNumberMessageHandler(IGitHubClient gitHubClient) : base(gitHubClient) { }
+    }
+}

--- a/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/GitHubIssueNumberMessageHandlers/SteakBotGitHubNumberParsingMessageHandler.cs
+++ b/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/GitHubIssueNumberMessageHandlers/SteakBotGitHubNumberParsingMessageHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.NumberParsingMessageHandlers.GitHubIssueNumberMessageHandlers
+{
+    internal class SteakBotGitHubNumberParsingMessageHandler : BaseGitHubIssueNumberMessageHandler
+    {
+        protected override string RepositoryOwner { get; } = "penev92";
+
+        protected override string RepositoryName { get; } = "SteakBot";
+
+        protected override Dictionary<string, int> MinimumHandledNumberPerKeyword { get; } = new Dictionary<string, int>
+        {
+            { "bot", 0 }
+        };
+    }
+}

--- a/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/GitHubIssueNumberMessageHandlers/SteakBotGitHubNumberParsingMessageHandler.cs
+++ b/SteakBot.Core/EventHandlers/CustomMessageHandlers/NumberParsingMessageHandlers/GitHubIssueNumberMessageHandlers/SteakBotGitHubNumberParsingMessageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Octokit;
 
 namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.NumberParsingMessageHandlers.GitHubIssueNumberMessageHandlers
 {
@@ -12,5 +13,7 @@ namespace SteakBot.Core.EventHandlers.CustomMessageHandlers.NumberParsingMessage
         {
             { "bot", 0 }
         };
+
+        public SteakBotGitHubNumberParsingMessageHandler(IGitHubClient gitHubClient) : base(gitHubClient) { }
     }
 }

--- a/SteakBot.Core/SteakBot.Core.csproj
+++ b/SteakBot.Core/SteakBot.Core.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Discord.Net" Version="2.1.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.15" />
     <PackageReference Include="NAudio" Version="1.9.0" />
+    <PackageReference Include="Octokit" Version="0.40.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
   </ItemGroup>
 

--- a/SteakBot/App.config
+++ b/SteakBot/App.config
@@ -3,6 +3,7 @@
     <appSettings>
         <add key="BotToken" value=""/>
         <add key="TrustedRoles" value="Parjoli;ParjoliInTraining"/>
+        <add key="GitHubIconsBaseUrl" value="http://openra.mine.nu/Icons/"/>
         <add key="memeCommandsRelativeFilePath" value="Assets/memeCommands.json"/>
         <add key="ggVoiceFile" value="Assets/gg.mp3"/>
         <add key="surpriseMf" value="Assets/surprise-motherfucker.mp3"/>

--- a/SteakBot/App.config
+++ b/SteakBot/App.config
@@ -4,6 +4,7 @@
         <add key="BotToken" value=""/>
         <add key="TrustedRoles" value="Parjoli;ParjoliInTraining"/>
         <add key="GitHubIconsBaseUrl" value="http://openra.mine.nu/Icons/"/>
+        <add key="ShowRepositoryIcon" value="True"/>
         <add key="memeCommandsRelativeFilePath" value="Assets/memeCommands.json"/>
         <add key="ggVoiceFile" value="Assets/gg.mp3"/>
         <add key="surpriseMf" value="Assets/surprise-motherfucker.mp3"/>

--- a/SteakBot/Program.cs
+++ b/SteakBot/Program.cs
@@ -14,6 +14,7 @@ namespace SteakBot
                 .AddCustomTypeReaders()
                 .AddDefaultModules()
                 .AddDefaultCustomMessageHandlers()
+                .AddGitHubIntegrationServices()
                 .BuildServiceProvider();
 
             using (var bot = new Bot(serviceProvider))


### PR DESCRIPTION
The code was, of course, copied left and right for a year and was first merged in Orabot, so copying it from there directly.
The significant difference is that the implementation in Orabot used RestSharp + hand-made web requests, while this uses a 3rd-party C# wrapper for the GitHub REST API - Octokit. Differences are minute, though.